### PR TITLE
update the DB date to a standardized format

### DIFF
--- a/ufc-predictor-aws-infra/lib/ufc-predictor-aws-infra-stack.ts
+++ b/ufc-predictor-aws-infra/lib/ufc-predictor-aws-infra-stack.ts
@@ -71,7 +71,7 @@ export class UfcPredictorInfraStack extends Stack {
       {
         namespace: "aws:elasticbeanstalk:application:environment",
         optionName: "FLASK_APP",
-        value: "ufc_event_predictor"
+        value: "application"
       },
       {
         namespace: "aws:elasticbeanstalk:application:environment",

--- a/ufc_predictor/app_factory.py
+++ b/ufc_predictor/app_factory.py
@@ -3,6 +3,7 @@ from ufc_predictor import db
 
 
 def create_app(config_object):
+    # TODO: Add logs
     app = Flask(__name__)
     app.config.from_object(config_object)
     db.mysql.init_app(app)

--- a/ufc_predictor/logistic_regression/views.py
+++ b/ufc_predictor/logistic_regression/views.py
@@ -13,12 +13,13 @@ logistic_regresion_views = Blueprint('logistic_regression', __name__)
 def logistic_regression():
     saturday_date = ""
     if pendulum.now().weekday() != 5:
-        saturday_date = pendulum.now().next(pendulum.SATURDAY).format("LL")
+        saturday_date = pendulum.now().next(pendulum.SATURDAY).format('YYYY-MM-DD')
     elif pendulum.now().weekday() == 6:
-        saturday_date = pendulum.now().previous(pendulum.SATURDAY).format("LL")
+        saturday_date = pendulum.now().previous(pendulum.SATURDAY).format('YYYY-MM-DD')
     else:
-        saturday_date = pendulum.now().format("LL")
+        saturday_date = pendulum.now().format('YYYY-MM-DD')
 
+    print(saturday_date)
     results, r_fighters, b_fighters, event_name = logistic_regression_service.predict(
         saturday_date)
     results_rf_bf = zip(results, r_fighters, b_fighters)

--- a/ufc_predictor/templates/logistic_regression/logistic_regression.html
+++ b/ufc_predictor/templates/logistic_regression/logistic_regression.html
@@ -3,7 +3,7 @@
 {% block content %}
     <header class="event__h1__container">
         <div class="event__h1__wrapper">
-            <h1>{{event_date}}: {{event_name}}</h1>
+            <h1>{{event_date}} : {{event_name}}</h1>
         </header>
     <div class="table_wrapper">
         <table class="event__table">


### PR DESCRIPTION
## What?
The date that was scraped using my ufcstats scrapy was in the format of `Month, Date Year`, but this caused issues for dates from 1-9. Pendulum generates the date as 01-09 so there was an error when grabbing the dates from the db.
## How?
Standardize the date strings using pendulum
