### PR TITLE
use sklearn StandardScalar class to normalize input and test data 

### DIFF
--- a/ufc_predictor/ml_models.py
+++ b/ufc_predictor/ml_models.py
@@ -2,7 +2,13 @@ from ufc_predictor.models.svm_model import SvmModel
 from ufc_predictor.models.log_reg_model import LogisticRegressionModel
 from sklearn.linear_model import LogisticRegression
 from sklearn import svm
+from sklearn.preprocessing import StandardScaler
 
 log_reg_clf = LogisticRegressionModel(LogisticRegression(random_state=2))
 # parameters of kernel=rbf, c=5, and gamma=0.01 were the parameters selected by GridSearchCV
 svm_clf = SvmModel(svm.SVC(kernel="rbf", C=5, gamma=0.01))
+
+# StandardScaler for models
+#z = (x-u)/s
+# u=mean and s=std
+standard_scalar = StandardScaler()

--- a/ufc_predictor/util.py
+++ b/ufc_predictor/util.py
@@ -90,18 +90,10 @@ def fit_ml_models():
     ml_models.svm_clf.fit(X, y)
 
 
-def standardize(X):
-    X_norm = X.copy()
-    mu = np.mean(X_norm, axis=0)
-    sigma = np.std(X_norm, axis=0)
-    X_norm = (X_norm - mu)/sigma
-    return X_norm
-
-
 def genererate_inputs_n_labels(fights_df):
     # Get data for model
     X = fights_df.loc[:, 4:].astype(float).to_numpy()
-    X = standardize(X)
+    X = ml_models.standard_scalar.fit_transform(X)
     y = fights_df.loc[:, 3].astype(float).to_numpy()
 
     return X, y
@@ -120,7 +112,7 @@ def saturday_date():
 
 def event_data(future_df):
     future_X = future_df.loc[:, 5:].astype(float).to_numpy()
-    future_X = standardize(future_X)
+    future_X = ml_models.standard_scalar.transform(future_X)
     r_fighters = future_df.loc[:, 3].values.tolist()
     b_fighters = future_df.loc[:, 4].values.tolist()
     event_name = future_df.loc[1, 2]


### PR DESCRIPTION
## What?
-  Normalize the test and input data using the same scalar
## Why?
While reading through nnfs, the author discusses how the same normalization scalar should be used for both the training and test data. My previous impl was using seperate scalars between the two sets. 
## How?
Use sklearn StandardScalar class to normalize all the data with the same scalars. This can be done using the fit_transform and transform methods.

https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.StandardScaler.html
